### PR TITLE
Add Wolfe Plaza project page

### DIFF
--- a/projects/bayview-community-pathway.html
+++ b/projects/bayview-community-pathway.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bayview Community Pathway - Green SF Now</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="projects.css">
+</head>
+
+<body>
+  <nav class="bg-tan sticky">
+    <div class="nav-container">
+      <a href="/" class="logo">
+        <img src="/images/green-sf-now-sierra-club-grassroots.webp" alt="Green SF Now Logo" class="logo-img">
+      </a>
+      <div class="menu">
+        <button class="mobile-menu-button">
+          <span class="sr-only">Open main menu</span>
+          <svg class="menu-icon" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd"
+              d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+              clip-rule="evenodd"></path>
+          </svg>
+        </button>
+        <div class="nav-links">
+          <a href="/projects/" class="nav-link">Projects</a>
+          <a href="/#events" class="nav-link">Events</a>
+          <a href="/blog/" class="nav-link">Blog</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <div class="breadcrumb">
+    <a href="/">Home</a> &gt; <a href="/projects/">Projects</a> &gt; Bayview Community Pathway
+  </div>
+
+  <main>
+    <section class="project-hero">
+      <div class="section-container">
+        <div class="hero-content">
+          <div class="hero-text">
+            <h1>Bayview Community Pathway</h1>
+            <p>Creating a safe, low-stress multimodal corridor with green infrastructure parallel to Third Street in Bayview-Hunters Point. This $15.5M project integrates transportation safety improvements with climate resilience through SFPUC green infrastructure funding, while celebrating the African American Arts & Cultural District.</p>
+          </div>
+          <div class="hero-cta">
+            <h3>Take Action to Support This Project</h3>
+            <div class="hero-cta-buttons">
+              <a href="https://www.sfmta.com/projects/bayview-community-pathway" target="_blank" class="cta-button">
+                📋 SFMTA Project Page
+              </a>
+              <button onclick="contactSteward()" class="cta-button">
+                📧 Get Project Updates
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-container">
+        <div class="project-details">
+          <div class="project-detail-card">
+            <h3>📍 Location</h3>
+            <p><strong>Route:</strong> Mendell Street, McKinnon Avenue, Lane Street, Underwood Avenue, and Keith Street<br>
+            <strong>Extent:</strong> Between Cargo Way and Carroll Avenue<br>
+            <strong>Neighborhood:</strong> Bayview-Hunters Point, San Francisco<br>
+            <strong>Cultural District:</strong> African American Arts & Cultural District<br>
+            <strong>Transit:</strong> Multiple connections to Muni Third Street light rail, T-Third line</p>
+          </div>
+
+          <div class="project-detail-card">
+            <h3>🌱 Project Overview</h3>
+            <p>The Bayview Community Pathway is a direct result of community outreach through the <a href="https://www.sfmta.com/projects/bayview-community-based-transportation-plan" target="_blank">Bayview Community-Based Transportation Plan</a>. During past SFMTA planning efforts, Bayview residents communicated the need to improve safety and comfort for people walking and biking along, across, and parallel to Third Street, the main arterial in the Bayview neighborhood.</p>
+            <p style="margin-top: 1rem;">Third Street and Lane Street are both on the <strong>High Injury Network</strong>, the 12% of city streets where 68% of transportation-related severe and fatal injuries occur. Community members identified a low-stress neighborhood route parallel to Third Street as a critical transportation priority to improve access to community destinations including the Southeast Community Center, Bayview YMCA, parks, schools, libraries, grocery stores, and transit connections.</p>
+            <p style="margin-top: 1rem;">The project was developed with input from several community organizations through presentations and a walk audit as part of the Caltrans Active Transportation Program (ATP) application process, receiving <strong>$15.5 million in grant funding</strong>.</p>
+          </div>
+
+          <div class="project-detail-card">
+            <h3>🤝 Supporters & Advocates</h3>
+            <p><strong>Lead Agency:</strong> <a href="https://www.sfmta.com" target="_blank">San Francisco Municipal Transportation Agency (SFMTA)</a><br>
+            <strong>Community Partners:</strong> San Francisco African American Arts & Cultural District, Bayview YMCA, Bayview Community-Based Transportation Plan stakeholders<br>
+            <strong>Funding:</strong> Caltrans Active Transportation Program (ATP) - $15.5 million grant<br>
+            <strong>Primary Contact:</strong> <a href="mailto:BayviewPathway@SFMTA.com">BayviewPathway@SFMTA.com</a></p>
+          </div>
+
+          <div class="project-detail-card">
+            <h3>💰 Funding</h3>
+            <p><strong>Secured Funding:</strong> $15.5 million Caltrans Active Transportation Program (ATP) grant<br>
+            <strong>Green Infrastructure Funding:</strong> San Francisco Public Utilities Commission (SFPUC) Green Infrastructure Capital Fund coordination for bioretention planters, permeable surfaces, and street tree expansion along the corridor</p>
+          </div>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🗺️ Site Location Map</h3>
+          <p><strong>Route:</strong> North-south corridor on Mendell Street, McKinnon Avenue, Lane Street, Underwood Avenue, and Keith Street<br>
+          <strong>Context:</strong> Bayview-Hunters Point neighborhood, parallel to Third Street between Cargo Way and Carroll Avenue</p>
+
+          <iframe width="100%" height="488" frameborder="0" title="Felt Map" src="https://felt.com/embed/map/Green-SF-Now-Priority-Greening-Projects-h9CNPq7OVQKaRNJy7i2H5kC?loc=37.731%2C-122.388%2C15z&legend=0&cooperativeGestures=1&link=1&geolocation=0&zoomControls=1&scaleBar=1" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+
+          <p><em>Interactive map showing the Bayview Community Pathway corridor in Bayview-Hunters Point.</em></p>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🌳 Green Infrastructure & Climate Resilience</h3>
+          <p>A key component of the Bayview Community Pathway is the integration of green infrastructure through coordination with the San Francisco Public Utilities Commission (SFPUC). This project represents a significant opportunity to address stormwater management and climate resilience in the Bayview-Hunters Point neighborhood.</p>
+          <ul>
+            <li><strong>Bioretention Planters:</strong> Install rain gardens and bioswales along the corridor to capture and filter stormwater runoff, reducing pollution entering the Bay and relieving pressure on the combined sewer system</li>
+            <li><strong>Permeable Surfaces:</strong> Incorporate permeable paving materials where feasible to increase groundwater absorption and reduce urban heat island effects</li>
+            <li><strong>Street Tree Expansion:</strong> Significantly increase tree canopy coverage along Mendell Street, McKinnon Avenue, Lane Street, Underwood Avenue, and Keith Street to provide shade, improve air quality, and create cooling corridors</li>
+            <li><strong>Native Plants & Greenery:</strong> Select climate-appropriate plantings that support local ecosystems, require less water, and enhance the visual character of the African American Arts & Cultural District</li>
+            <li><strong>SFPUC Partnership:</strong> Coordinate with SFPUC Green Infrastructure Capital Fund to maximize environmental benefits and ensure integration with citywide climate resilience goals</li>
+          </ul>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🚴 Multimodal Transportation Improvements</h3>
+          <ul>
+            <li><strong>Safety Infrastructure:</strong> Speed humps, sidewalk extensions, raised crosswalks, and traffic calming measures to create a safer corridor for people walking and biking</li>
+            <li><strong>Cultural District Enhancement:</strong> Pedestrian-friendly public spaces for gathering and unique street markings celebrating the African American Arts & Cultural District through partnership with SFAAACD</li>
+            <li><strong>Education Programs:</strong> Group bike classes and community rides/walks in partnership with Bayview YMCA; Vision Zero Campaign addressing vehicle speeding dangers</li>
+            <li><strong>Community Events:</strong> Open Street events along the corridor in partnership with San Francisco African American Arts & Cultural District</li>
+            <li><strong>Evaluation:</strong> Monitor effectiveness of improvements before and after construction, responsive to community definitions of safety</li>
+          </ul>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🎯 Project Goals</h3>
+          <ul>
+            <li><strong>Climate Resilience & Green Infrastructure:</strong> Partner with SFPUC to implement bioretention planters, permeable surfaces, and expanded tree canopy for stormwater management, groundwater recharge, and urban cooling—addressing climate change impacts in an environmental justice community</li>
+            <li><strong>Respond to Community Priorities:</strong> Address transportation priorities identified in the Bayview Community-Based Transportation Plan through direct community engagement</li>
+            <li><strong>Improve Safety:</strong> Address High Injury Network corridors (Third Street and Lane Street) and enhance transportation safety for people walking and biking through traffic calming and infrastructure improvements</li>
+            <li><strong>Increase Connectivity:</strong> Provide a low-stress alternative route to Third Street, improving access to community destinations including schools, parks, recreation centers, libraries, healthcare facilities, and grocery stores</li>
+            <li><strong>Prioritize Vulnerable Users:</strong> Center mobility outcomes for seniors, youth, and people with disabilities</li>
+            <li><strong>Support Community Ownership:</strong> Preserve sense of place and belonging through street markings and murals celebrating the African American Arts & Cultural District</li>
+            <li><strong>Build Understanding:</strong> Encourage community use through partnerships with local organizations on walks, rides, bike classes, and open street events</li>
+          </ul>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>⚠️ High Injury Network Context</h3>
+          <p>The Bayview Community Pathway directly addresses San Francisco's Vision Zero commitment to eliminate traffic deaths. Third Street and Lane Street are part of the city's <strong>High Injury Network</strong> - just 12% of San Francisco streets where 68% of severe and fatal traffic injuries occur.</p>
+          <p style="margin-top: 1rem;">By creating a safer parallel route and implementing traffic calming measures, this project responds to urgent community safety needs in a neighborhood that has historically faced disproportionate transportation safety challenges.</p>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>📈 Current Status & Next Steps</h3>
+          <p><strong>Critical Milestone:</strong> Public hearing at SFMTA Board of Directors meeting on <strong>Tuesday, December 2, 2025 at 1:00 pm</strong> to consider proposed pedestrian safety and bike connection changes<br>
+          <strong>Current Phase:</strong> Planning and Design<br>
+          <strong>Construction Timeline:</strong> Completion planned for 2028<br>
+          <strong>How to Participate:</strong> <a href="https://www.sfmta.com/projects/bayview-community-pathway" target="_blank">Visit the SFMTA public hearing webpage</a> for information about how to participate in the SFMTA Board meeting<br>
+          <strong>Get Updates:</strong> <a href="https://www.sfmta.com/projects/bayview-community-pathway" target="_blank">Sign up for project updates from SFMTA</a></p>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>📄 Project Resources</h3>
+          <ul>
+            <li><a href="https://www.sfmta.com/projects/bayview-community-pathway" target="_blank">SFMTA Bayview Community Pathway Official Project Page</a></li>
+            <li><a href="https://www.sfmta.com/media/43820/download" target="_blank">Proposed Design - Bayview Community Pathway (PDF)</a></li>
+            <li><a href="https://www.sfmta.com/media/39584/download" target="_blank">Bayview Corridor Project Map (PDF)</a></li>
+            <li><a href="https://www.sfmta.com/projects/bayview-community-based-transportation-plan" target="_blank">Bayview Community-Based Transportation Plan</a></li>
+            <li>Bayview Corridor Fact Sheets available in <a href="https://www.sfmta.com/projects/bayview-community-pathway" target="_blank">English, Chinese, and Spanish</a></li>
+          </ul>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>📰 Related SFMTA Projects</h3>
+          <ul>
+            <li><a href="https://www.sfmta.com/projects/bayview-community-based-transportation-plan" target="_blank">Bayview Community Based Transportation Plan</a> - A community-led plan to invest in transportation in the Bayview</li>
+            <li><a href="https://www.sfmta.com/projects/bayview-community-shuttle" target="_blank">Bayview Community Shuttle</a></li>
+            <li><a href="https://www.sfmta.com/projects/bayview-cbtp-quick-build-projects" target="_blank">Bayview CBTP Quick-Build Projects</a> - Improving mobility and safety in a culturally rich community</li>
+            <li><a href="https://www.sfmta.com/projects/evans-avenue-quick-build" target="_blank">Evans Avenue Quick-Build</a> - Making biking, walking, and connecting to the 19 Polk between Cesar Chavez and 3rd streets safer</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <div class="footer-content">
+        <span>© 2025 Green SF Now</span>
+        <div class="footer-links">
+          <a href="/#what" class="footer-link">What</a>
+          <a href="/#why" class="footer-link">Why</a>
+          <a href="/#contact" class="footer-link">Contact</a>
+          <a href="https://github.com/kfarr/greensfnow" class="footer-link">Edit on Github</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Simple mobile menu toggle
+    document.querySelector('.mobile-menu-button').addEventListener('click', function () {
+      document.querySelector('.nav-links').classList.toggle('active');
+    });
+
+    // Contact for project updates
+    function contactSteward() {
+      const mailtoUrl = 'mailto:BayviewPathway@SFMTA.com?subject=Bayview%20Community%20Pathway%20Inquiry';
+      window.location.href = mailtoUrl;
+    }
+  </script>
+</body>
+
+</html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -274,6 +274,42 @@
               <div class="project-cta">Show Project Page →</div>
             </div>
           </a>
+
+          <a href="/projects/hayes-promenade.html" class="project-card">
+            <img src="/projects/images/hayes-promenade-2023.12.01.holiday.stroll_small.jpg" alt="Hayes Promenade" class="project-image">
+            <div class="project-content">
+              <h3 class="project-title">Hayes Promenade</h3>
+              <p class="project-location">📍 Hayes Valley • Hayes between Octavia & Gough</p>
+              <p class="project-description">
+                Transforming a successful weekend street activation into a permanent green pedestrian plaza in the heart of Hayes Valley. Since 2020, Hayes Promenade has demonstrated what city streets can be: safe, vibrant, and people-centered spaces.
+              </p>
+              <div class="project-cta">Show Project Page →</div>
+            </div>
+          </a>
+
+          <a href="/projects/carolina-triangle.html" class="project-card">
+            <img src="/projects/images/carolina-triangle-current-1.jpeg" alt="Carolina Triangle" class="project-image">
+            <div class="project-content">
+              <h3 class="project-title">Carolina Triangle</h3>
+              <p class="project-location">📍 Showplace Square • Channel & Carolina</p>
+              <p class="project-description">
+                Reclaiming an illegally occupied triangle of public right-of-way at Channel and Carolina Streets, transforming it into green infrastructure with neighborhood amenities for CCA students and the Showplace Square community.
+              </p>
+              <div class="project-cta">Show Project Page →</div>
+            </div>
+          </a>
+
+          <a href="/projects/wolfe-plaza.html" class="project-card">
+            <img src="/projects/images/wolfe-plaza-aerial.jpeg" alt="Wolfe Plaza" class="project-image">
+            <div class="project-content">
+              <h3 class="project-title">Wolfe Plaza</h3>
+              <p class="project-location">📍 Showplace Square • 8th St spur between Irwin & 16th</p>
+              <p class="project-description">
+                Transforming a former Streets to Parks site into a permanent green open space for residents, local businesses, and the CCA university campus. Close to half an acre of potential green space in a neighborhood that needs it.
+              </p>
+              <div class="project-cta">Show Project Page →</div>
+            </div>
+          </a>
         </div>
       </div>
     </section>

--- a/projects/wolfe-plaza.html
+++ b/projects/wolfe-plaza.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wolfe Plaza - Green SF Now</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="projects.css">
+</head>
+
+<body>
+  <nav class="bg-tan sticky">
+    <div class="nav-container">
+      <a href="/" class="logo">
+        <img src="/images/green-sf-now-sierra-club-grassroots.webp" alt="Green SF Now Logo" class="logo-img">
+      </a>
+      <div class="menu">
+        <button class="mobile-menu-button">
+          <span class="sr-only">Open main menu</span>
+          <svg class="menu-icon" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd"
+              d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+              clip-rule="evenodd"></path>
+          </svg>
+        </button>
+        <div class="nav-links">
+          <a href="/projects/" class="nav-link">Projects</a>
+          <a href="/#events" class="nav-link">Events</a>
+          <a href="/blog/" class="nav-link">Blog</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <div class="breadcrumb">
+    <a href="/">Home</a> &gt; <a href="/projects/">Projects</a> &gt; Wolfe Plaza
+  </div>
+
+  <main>
+    <section class="project-hero">
+      <div class="section-container">
+        <div class="hero-content">
+          <div class="hero-text">
+            <h1>Wolfe Plaza</h1>
+            <p>Transforming a former Streets to Parks site into a permanent green open space for residents, local businesses, and the CCA university campus nearby</p>
+          </div>
+          <div class="hero-cta">
+            <h3>Take Action to Support This Project</h3>
+            <div class="hero-cta-buttons">
+              <button onclick="generateSupportEmail()" class="cta-button">
+                📧 Send Letter of Support
+              </button>
+              <button onclick="contactSteward()" class="cta-button">
+                🤝 Contact the Steward
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-container">
+        <div class="project-details">
+          <div class="project-detail-card">
+            <h3>📍 Location</h3>
+            <p><strong>Location:</strong> 8th Street spur between Irwin and 16th Street<br>
+            <strong>Neighborhood:</strong> Showplace Square / Design District, San Francisco<br>
+            <strong>Adjacent to:</strong> Wolfe's Lunch Cafe, CCA Campus<br>
+            <strong>Project Area:</strong> Close to half an acre (including adjacent public right-of-way)<br>
+            <strong>Transit:</strong> Near 16th St line, less than 1 mile from Caltrain station, 1 block from new 17th St bike lane</p>
+          </div>
+
+          <div class="project-detail-card">
+            <h3>🌱 Project Overview</h3>
+            <p>Wolfe Plaza proposes to close the 8th Street spur between Irwin and 16th Street—a historic vestige of the old street grid that forms a triangle east of Wolfe's Lunch Cafe. This unusual configuration creates both a safety hazard and an opportunity for transformation.</p>
+            <p style="margin-top: 1rem;">The project would reclaim this unnecessary street segment and transform it into a green public space with significant opportunities for traffic calming at the 8th/Irwin/Wisconsin intersection through bulbouts and intersection redesign. The space has already proven successful as a former Streets to Parks activation site, demonstrating community support and viability for permanent transformation.</p>
+            <p style="margin-top: 1rem;">With potential access to adjacent public right-of-way, the project could encompass close to half an acre, creating a substantial new green space in a neighborhood that lacks open space for residents, students, and local businesses.</p>
+          </div>
+
+          <div class="project-detail-card">
+            <h3>🤝 Supporters & Advocates</h3>
+            <p><strong>Lead Advocates:</strong> Potrero Boosters Neighborhood Association, Friends of Jackson Park, Green SF Now, Sierra Club Creeks<br>
+            <strong>Key Stakeholders:</strong> California College of the Arts (CCA), Live Oak School<br>
+            <strong>Primary Contact:</strong> <a href="mailto:president@potreroboosters.org">Potrero Boosters</a></p>
+          </div>
+
+          <div class="project-detail-card">
+            <h3>💰 Potential Funding Sources</h3>
+            <p><strong>Private:</strong> Donations from local businesses, CCA partnership<br>
+            <strong>City Programs:</strong> SFPUC Green Infrastructure Capital Fund, DPW street improvement programs, stormwater management grants<br>
+            <strong>State Funding:</strong> California Urban Greening Program</p>
+          </div>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🗺️ Site Location Map</h3>
+          <p><strong>Location:</strong> 8th Street spur between Irwin and 16th Street<br>
+          <strong>Context:</strong> Showplace Square neighborhood, near CCA campus and Potrero residential areas</p>
+
+          <iframe width="100%" height="488" frameborder="0" title="Felt Map" src="https://felt.com/embed/map/Green-SF-Now-Priority-Greening-Projects-h9CNPq7OVQKaRNJy7i2H5kC?loc=37.7683585,-122.4009268,18.3z&legend=0&cooperativeGestures=1&link=1&geolocation=0&zoomControls=1&scaleBar=1" referrerpolicy="strict-origin-when-cross-origin" style="border-radius: 0.5rem; margin: 1rem 0;"></iframe>
+
+          <p><em>Interactive map showing Wolfe Plaza location in Showplace Square / Design District.</em></p>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🎯 Why This Location Needs Action</h3>
+          <ul>
+            <li><strong>Proven Success:</strong> This site was successfully activated through the Streets to Parks program, demonstrating community support and viability for permanent transformation</li>
+            <li><strong>Historic Vestige:</strong> The 8th Street spur is an unnecessary remnant of the old street grid that serves no current transportation function—16th Street is immediately adjacent and serves the same purpose</li>
+            <li><strong>Safety Concerns:</strong> The current configuration creates a dangerous intersection at 8th/Irwin/Wisconsin where vehicles can make high-speed turns without stop signs in one direction. CCA has identified this as a particularly dangerous intersection for their students</li>
+            <li><strong>Lack of Open Space:</strong> The Showplace Square community, including CCA students and nearby residents, lack accessible green space despite proximity to major destinations and institutions</li>
+            <li><strong>CCA Campus Proximity:</strong> Immediately adjacent to CCA's campus, providing opportunities for student participation in activation, outdoor classrooms, and safe gathering spaces</li>
+            <li><strong>Expanded Area Potential:</strong> Additional public right-of-way on the northeast parcel could significantly expand the project to create a legitimate park-scale green space</li>
+            <li><strong>Stormwater Management:</strong> The large area presents excellent opportunities for stormwater collection and green infrastructure</li>
+            <li><strong>Traffic Calming Opportunity:</strong> Closing the street spur enables significant intersection redesign with bulbouts to improve pedestrian safety and reduce the oversized intersection footprint</li>
+          </ul>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🌳 Vision for Potential Uses</h3>
+          <ul>
+            <li><strong>Dog Park / Dog Run:</strong> Potential for a dog park or dog run, especially if adjacent public property is available, helping to alleviate pressure on nearby Jackson Park during its planned renovation</li>
+            <li><strong>Community Plaza:</strong> Green plaza with tables and chairs for residents and patrons of Wolfe's Lunch Cafe and other nearby businesses (including restaurants at Potrero 1010)</li>
+            <li><strong>CCA Programming:</strong> Potential outdoor classroom space or other activities for CCA students, fostering community-university engagement</li>
+            <li><strong>Green Infrastructure:</strong> Stormwater collection and management, permeable surfaces, street trees and plantings</li>
+            <li><strong>Traffic Safety Improvements:</strong> Bulbouts at 8th/Irwin/Wisconsin intersection corners to slow traffic, shorten pedestrian crossings, and add greenery</li>
+            <li><strong>Event Space:</strong> Flexible space for community events, craft fairs, and neighborhood gatherings (as demonstrated by successful weekend activations)</li>
+          </ul>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>🚗 Addressing Parking & Access Concerns</h3>
+          <p>The project team recognizes that nearby businesses, including Wolfe's Lunch Cafe, may have concerns about parking and access. The vision includes:</p>
+          <ul>
+            <li><strong>Parking Solutions:</strong> Working with affected businesses to identify appropriate parking solutions, potentially including perpendicular parking on Wisconsin Street or other nearby locations</li>
+            <li><strong>Outdoor Seating Opportunities:</strong> Creating new opportunities for outdoor seating and dining that could benefit local restaurants</li>
+            <li><strong>Increased Foot Traffic:</strong> Plaza activation typically increases pedestrian activity and business for nearby establishments</li>
+            <li><strong>Delivery Access:</strong> Ensuring appropriate accommodation for business deliveries and essential vehicle access</li>
+          </ul>
+          <p style="margin-top: 1rem;">These details will be refined through community engagement as the project develops, ensuring that solutions work for all stakeholders while prioritizing public space transformation.</p>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>📈 Current Status</h3>
+          <p><strong>Phase:</strong> Coalition Building and Negotiation<br>
+          <strong>Next Steps:</strong> Formalize community coalition, engage with CCA and local businesses, coordinate with city agencies on traffic calming and green infrastructure opportunities, clarify public right-of-way boundaries<br>
+          <strong>Timeline:</strong> TBD</p>
+        </div>
+
+        <div class="project-detail-card">
+          <h3>📸 Project Gallery</h3>
+          <div class="gallery-grid">
+            <div class="gallery-item">
+              <img src="images/wolfe-plaza-craft-fair-1.jpeg" alt="Craft fair activation at Wolfe Plaza">
+              <div class="gallery-caption">
+                Weekend craft fair activation showing successful community use of the space
+              </div>
+            </div>
+            <div class="gallery-item">
+              <img src="images/wolfe-plaza-craft-fair-2.jpeg" alt="Community gathering at Wolfe Plaza">
+              <div class="gallery-caption">
+                Community members enjoying the space during a Streets to Parks activation
+              </div>
+            </div>
+            <div class="gallery-item">
+              <img src="images/wolfe-plaza-aerial.jpeg" alt="Aerial view of Wolfe Plaza site">
+              <div class="gallery-caption">
+                Aerial view showing the 8th Street spur and potential project area
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <div class="footer-content">
+        <span>© 2025 Green SF Now</span>
+        <div class="footer-links">
+          <a href="/#what" class="footer-link">What</a>
+          <a href="/#why" class="footer-link">Why</a>
+          <a href="/#contact" class="footer-link">Contact</a>
+          <a href="https://github.com/kfarr/greensfnow" class="footer-link">Edit on Github</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Simple mobile menu toggle
+    document.querySelector('.mobile-menu-button').addEventListener('click', function () {
+      document.querySelector('.nav-links').classList.toggle('active');
+    });
+
+    // Generate support email for Wolfe Plaza
+    function generateSupportEmail() {
+      const recipients = [
+        'daniel.lurie@sfgov.org',
+        'carla.short@sfdpw.org',
+        'dennis.herrera@sfwater.org',
+        'sminick@sfwater.org',
+        'julie.kirschbaum@sfmta.com',
+        'alexandra.c.sweet@sfgov.org',
+        'a.john-baptiste@sfgov.org',
+        'amar.bhardwaj.myr@sfgov.org',
+        'javier.rivera@sfdpw.org',
+        'logan.hehn@sfdpw.org',
+        'Madison.R.Tam@sfgov.org',
+        'Monica.Giacomucci@sfgov.org',
+        'DorseyStaff@sfgov.org'
+      ];
+
+      const ccRecipients = [
+        'CColwick@sfwater.org',
+        'Viktoriya.a.wise@sfmta.com'
+      ];
+
+      const bccRecipients = [
+        'kieran.farr@gmail.com'
+      ];
+
+      const subject = "I support Wolfe Plaza - Transforming a Street Spur into Community Green Space!";
+
+      const emailBody = `Dear Mayor Lurie, Supervisor Dorsey, and City agency staff,
+
+As a resident of San Francisco, I'm writing to express my strong support for the Wolfe Plaza project, which would transform the unnecessary 8th Street spur between Irwin and 16th Street into a permanent green open space serving residents, local businesses, and the CCA university campus.
+
+This historic vestige of the old street grid currently serves no essential transportation function—16th Street immediately adjacent serves the same purpose. Meanwhile, the unusual configuration creates a dangerous intersection that CCA has identified as particularly hazardous for their students.
+
+The Wolfe Plaza project proposes to reclaim this space and create community benefits:
+• Safe, accessible outdoor space for CCA students, nearby residents, and local businesses
+• Potential dog park or dog run to alleviate pressure on Jackson Park during planned renovations
+• Stormwater management infrastructure in an area well-suited for green infrastructure
+• Traffic calming improvements with bulbouts at the 8th/Irwin/Wisconsin intersection
+• Community plaza space for dining, events, and neighborhood gatherings
+• Expansion of green space in Showplace Square, a neighborhood that lacks open space
+
+This location has already proven successful through the Streets to Parks program, demonstrating strong community support for permanent transformation. With potential access to adjacent public right-of-way, the project could create close to half an acre of new green space.
+
+The timing is right to work with project advocates, CCA, local businesses, and Potrero Boosters to ensure this unnecessary street spur becomes a thriving community asset that serves people instead of creating safety hazards.
+
+I encourage you to support the Wolfe Plaza project and work with advocates to transform this space into the green infrastructure our community needs.
+
+For more information, please visit: https://greensfnow.org/projects/wolfe-plaza.html
+
+Thank you for your time and consideration.
+
+Sincerely,`;
+
+      // Create mailto URL with all recipients
+      const mailtoUrl = `mailto:${recipients.join(',')}?cc=${ccRecipients.join(',')}&bcc=${bccRecipients.join(',')}&subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(emailBody)}`;
+
+      // Open email client
+      window.location.href = mailtoUrl;
+    }
+
+    // Contact steward email
+    function contactSteward() {
+      const mailtoUrl = 'mailto:president@potreroboosters.org?subject=Wolfe%20Plaza%20Inquiry';
+      window.location.href = mailtoUrl;
+    }
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Creates a new project page for Wolfe Plaza based on community discussions and planning meetings. The page includes:

- Project overview and location details for the 8th Street spur between Irwin and 16th
- Vision for transforming the former Streets to Parks site into permanent green space
- Information about supporters, stakeholders, and funding sources
- Details about safety improvements and traffic calming opportunities
- Potential uses including dog park, community plaza, and CCA programming
- Added Wolfe Plaza, Hayes Promenade, and Carolina Triangle to projects index

The page structure follows the established format from other project pages and includes sections for location, overview, supporters, funding, current status, and vision for future uses.